### PR TITLE
Resolve bug with dependebot

### DIFF
--- a/src/main/java/io/bootique/tools/release/model/persistent/Author.java
+++ b/src/main/java/io/bootique/tools/release/model/persistent/Author.java
@@ -9,12 +9,6 @@ public class Author extends _Author implements Comparable<Author> {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String NULL_GITHUB_ID = "null-github-id";
-
-    public Author() {
-        githubId = NULL_GITHUB_ID;
-    }
-
     @Override
     @JsonProperty("__typename")
     public String getType() {

--- a/src/main/resources/io/bootique/tools/release/service/github/pr.query
+++ b/src/main/resources/io/bootique/tools/release/service/github/pr.query
@@ -24,6 +24,9 @@ query ($owner: String!, $name: String!, $totalCount: Int!) {
                 id
                 name
               }
+              ... on Bot {
+                id
+              }
             }
             labels(first: 10) {
               totalCount


### PR DESCRIPTION
There was issue with absent githubId for dependabot (author type : "bot" ). Attribute "id" was added to graphQL query for author (type "bot").